### PR TITLE
bugfix: declare ts types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "credential status aggregator for did-jwt",
   "main": "dist/index.js",
+  "types": "lib/index.d.ts",
+  "source": "src/index.ts",
+  "module": "lib/index.js",
   "scripts": {
     "build": "tsc",
     "test": "jest",


### PR DESCRIPTION
This fixes a problem with library usage where the typescript types and interfaces would be unknown to users.