### PR TITLE
Require a `DIDDocument` for `checkStatus()`

### DIFF
--- a/src/__tests__/basicTests.ts
+++ b/src/__tests__/basicTests.ts
@@ -4,8 +4,30 @@ import {
   Status,
   StatusMethod,
   StatusResolver,
-  CredentialStatus
+  CredentialStatus,
+  DIDDocument
 } from '../index'
+
+const referenceDoc = {
+              "@context": "https://w3id.org/did/v1",
+              "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+              "authentication": [
+                {
+                  "type": "Secp256k1SignatureAuthentication2018",
+                  "publicKey": [
+                    "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                  ]
+                }
+              ],
+              "publicKey": [
+                {
+                  "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                  "type": "Secp256k1VerificationKey2018",
+                  "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                  "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                }
+              ]
+            } as DIDDocument
 
 test('should be able to instantiate Status', () => {
   expect(new Status()).not.toBeNil()
@@ -19,7 +41,8 @@ test('should be able to call checkStatus', () => {
 test('should reject unknown status method', async () => {
   const checker = new Status()
   const statusEntry = await checker.checkStatus(
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNTExNTYsInN0YXR1cyI6eyJpZCI6InJpbmtlYnk6MHhTdGF0dXNSZWdpc3RyeUFkZHJlc3MiLCJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.hNFm3JDwoyNX2YHPlioHkR986ETPPWYuBV_9J9HYVaGKUVeKCrrO3a5ZExP3WVPv21P7NlpHeYMipjKQF_G1lAE'
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNTExNTYsInN0YXR1cyI6eyJpZCI6InJpbmtlYnk6MHhTdGF0dXNSZWdpc3RyeUFkZHJlc3MiLCJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.hNFm3JDwoyNX2YHPlioHkR986ETPPWYuBV_9J9HYVaGKUVeKCrrO3a5ZExP3WVPv21P7NlpHeYMipjKQF_G1lAE',
+    referenceDoc
   )
   expect(statusEntry).toStrictEqual({
     error:
@@ -30,7 +53,8 @@ test('should reject unknown status method', async () => {
 test('should pass through credential with no status requirement', async () => {
   const checker = new Status()
   const statusEntry = await checker.checkStatus(
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjI4NzUsIm5hbWUiOiJ1UG9ydCBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.dTkC_-pLizlz2LkwZBIVPLiFJBGI51urLB2sPgivemf78u3RpB2gJG7Xd4BGUFA3kjOoujAMFNKX4MakoskU3gA'
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjI4NzUsIm5hbWUiOiJ1UG9ydCBEZXZlbG9wZXIiLCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.dTkC_-pLizlz2LkwZBIVPLiFJBGI51urLB2sPgivemf78u3RpB2gJG7Xd4BGUFA3kjOoujAMFNKX4MakoskU3gA',
+    referenceDoc
   )
   expect(statusEntry).toStrictEqual({})
 })
@@ -43,14 +67,15 @@ test('should check status according to registered method', async () => {
   const checker = new Status({ CustomStatusChecker: checkStatus })
 
   const statusEntry = await checker.checkStatus(
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjM1NjQsInN0YXR1cyI6eyJ0eXBlIjoiQ3VzdG9tU3RhdHVzQ2hlY2tlciIsImlkIjoiZG9uJ3QgY2FyZSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.zJmp94s0yq7HYHhVT1A0GFD4-51vwpsc7JPn35mMgZJ7WVVQmlp07u13Uu0vqsFprixHL3zRfd9z-yWKUMTyWQA'
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjM1NjQsInN0YXR1cyI6eyJ0eXBlIjoiQ3VzdG9tU3RhdHVzQ2hlY2tlciIsImlkIjoiZG9uJ3QgY2FyZSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.zJmp94s0yq7HYHhVT1A0GFD4-51vwpsc7JPn35mMgZJ7WVVQmlp07u13Uu0vqsFprixHL3zRfd9z-yWKUMTyWQA',
+    referenceDoc
   )
   expect(statusEntry).toStrictEqual({ 'custom method works': true })
 })
 
 test('sample StatusResolver with easy registration', async () => {
   class CustomStatusChecker implements StatusResolver {
-    checkStatus: StatusMethod = async (credential: string) => {
+    checkStatus: StatusMethod = async (credential: string, doc: DIDDocument) => {
       return { revoked: false }
     }
     asStatusMethod = { CustomStatusChecker: this.checkStatus }
@@ -61,7 +86,8 @@ test('sample StatusResolver with easy registration', async () => {
   })
 
   const statusEntry = await checker.checkStatus(
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjM1NjQsInN0YXR1cyI6eyJ0eXBlIjoiQ3VzdG9tU3RhdHVzQ2hlY2tlciIsImlkIjoiZG9uJ3QgY2FyZSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.zJmp94s0yq7HYHhVT1A0GFD4-51vwpsc7JPn35mMgZJ7WVVQmlp07u13Uu0vqsFprixHL3zRfd9z-yWKUMTyWQA'
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzIzNjM1NjQsInN0YXR1cyI6eyJ0eXBlIjoiQ3VzdG9tU3RhdHVzQ2hlY2tlciIsImlkIjoiZG9uJ3QgY2FyZSJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.zJmp94s0yq7HYHhVT1A0GFD4-51vwpsc7JPn35mMgZJ7WVVQmlp07u13Uu0vqsFprixHL3zRfd9z-yWKUMTyWQA',
+    referenceDoc
   )
   expect(statusEntry).toStrictEqual({ revoked: false })
 })

--- a/src/__tests__/basicTests.ts
+++ b/src/__tests__/basicTests.ts
@@ -14,9 +14,7 @@ const referenceDoc = {
               "authentication": [
                 {
                   "type": "Secp256k1SignatureAuthentication2018",
-                  "publicKey": [
-                    "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
-                  ]
+                  "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
                 }
               ],
               "publicKey": [

--- a/src/__tests__/basicTests.ts
+++ b/src/__tests__/basicTests.ts
@@ -4,9 +4,10 @@ import {
   Status,
   StatusMethod,
   StatusResolver,
-  CredentialStatus,
-  DIDDocument
+  CredentialStatus
 } from '../index'
+
+import { DIDDocument } from 'did-resolver'
 
 const referenceDoc = {
               "@context": "https://w3id.org/did/v1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import { decodeJWT } from 'did-jwt'
 import { DIDDocument, PublicKey } from 'did-resolver'
 
-export type DIDDocument = DIDDocument
-
 /**
  * Represents the result of a status check
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 import { decodeJWT } from 'did-jwt'
+import { DIDDocument, PublicKey } from 'did-resolver'
+
+export type DIDDocument = DIDDocument
 
 /**
  * Represents the result of a status check
@@ -16,7 +19,6 @@ export interface CredentialStatus {
  * ```json
  * status : { type: "EthrStatusRegistry2019", id: "rinkeby:0xregistryAddress" }
  * ```
- *
  */
 export interface StatusEntry {
   type: string
@@ -48,7 +50,8 @@ export interface StatusResolver {
  * The method signature expected to be implemented by credential status resolvers
  */
 export type StatusMethod = (
-  credential: string
+  credential: string,
+  didDoc: DIDDocument
 ) => Promise<null | CredentialStatus>
 
 interface JWTPayloadWithStatus {
@@ -72,9 +75,9 @@ export class Status implements StatusResolver {
    * Example:
    * ```typescript
    * const status = new Status({
-   *   ...new EthrStatusRegistry(config).asStatusMethod,
-   *   "CredentialStatusList2017": new CredentialStatusList2017().checkStatus,
-   *   "CustomStatusChecker": customStatusCheckerMethod
+   *   ...new EthrStatusRegistry(config).asStatusMethod,                       //using convenience method
+   *   "CredentialStatusList2017": new CredentialStatusList2017().checkStatus, //referencing a checkStatus implementation
+   *   "CustomStatusChecker": customStatusCheckerMethod                        //directly referencing an independent method
    * })
    * ```
    */
@@ -82,7 +85,7 @@ export class Status implements StatusResolver {
     this.registry = registry
   }
 
-  checkStatus(credential: string): Promise<null | CredentialStatus> {
+  checkStatus(credential: string, didDoc: DIDDocument): Promise<null | CredentialStatus> {
     // TODO: validate the credential to be VerifiableCredential or VerifiablePresentation
     const decoded = decodeJWT(credential)
     const statusEntry = (decoded.payload as JWTPayloadWithStatus).status
@@ -96,7 +99,7 @@ export class Status implements StatusResolver {
     const method = this.registry[statusEntry.type]
 
     if (typeof method !== 'undefined' && method != null) {
-      return method(credential)
+      return method(credential, didDoc)
     } else {
       return new Promise((resolve, reject) => {
         // Once the credential status mechanisms in W3C get more stable, perhaps this can become a `reject`


### PR DESCRIPTION
The issuer [`DIDDocument`](https://github.com/decentralized-identity/did-resolver/blob/develop/src/resolver.ts#L15) is expected to be obtained during a verification step that is done pre-status-check or directly from a [`Resolver`](https://github.com/decentralized-identity/did-resolver#resolving-a-did-document)

This will be used by `StatusMethod`s instead of internally parsing the credential to extract the issuer.
This solves the need for repeated Resolver calls and creates the possibility of using the keys or other entries in the DIDDocument for status-checks

This will be a BREAKING CHANGE