### PR TITLE
fix(ci): add multiple build targets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript']
-}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,19 @@
   "name": "credential-status",
   "version": "2.0.1",
   "description": "credential status aggregator for did-jwt",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
   "source": "src/index.ts",
-  "module": "lib/index.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.module.js",
+  "unpkg": "lib/index.umd.js",
+  "types": "lib/index.d.ts",
+  "umd:main": "lib/index.umd.js",
+  "exports": {
+    ".": {
+      "require": "lib/index.cjs",
+      "import": "lib/index.module.js"
+    }
+  },
   "scripts": {
     "build": "microbundle --compress=false",
     "test": "jest",


### PR DESCRIPTION
As discussed [here](https://github.com/uport-project/veramo/pull/874#issuecomment-1123955226), this lib was missing some correct exports.

This PR attempts to correct that